### PR TITLE
Add Linux support to CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,20 +3,35 @@ project(NukeFlareSim LANGUAGES CXX CUDA)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CUDA_STANDARD 17)
-set(CMAKE_CUDA_ARCHITECTURES 75 80 86 89 90)  # Turing, Ampere, Ada, Hopper
 
-# Match Nuke's MSVC runtime — must be MultiThreaded DLL (/MD).
-# Mixing runtimes causes heap corruption and hard-to-diagnose crashes.
-set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreadedDLL")
-set(CMAKE_CUDA_RUNTIME_LIBRARY Shared)   # use cudart.dll; avoids LIBCMT conflict with Nuke's /MD
+# GPU architectures: Turing, Ampere, Ada, Hopper, Blackwell
+set(CMAKE_CUDA_ARCHITECTURES 75 80 86 89 90 120)
+
+if(MSVC)
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreadedDLL")
+endif()
+# Static on Linux: avoids conflicts with Nuke's bundled libcudart.so.11.
+# Shared on Windows: the original default; avoids LIBCMT conflict with Nuke's /MD.
+if(WIN32)
+    set(CMAKE_CUDA_RUNTIME_LIBRARY Shared)
+else()
+    set(CMAKE_CUDA_RUNTIME_LIBRARY Static)
+endif()
 
 # ---------------------------------------------------------------------------
 # Paths — override on the cmake command line if Nuke is installed elsewhere
 # ---------------------------------------------------------------------------
-set(NDK_ROOT "C:/Program Files/Nuke16.0v1/include"
-    CACHE PATH "Nuke NDK include directory")
-set(NUKE_LIB_DIR "C:/Program Files/Nuke16.0v1"
-    CACHE PATH "Nuke library directory (contains DDImage.lib / Ndk.lib)")
+if(WIN32)
+    set(NDK_ROOT "C:/Program Files/Nuke16.0v1/include"
+        CACHE PATH "Nuke NDK include directory")
+    set(NUKE_LIB_DIR "C:/Program Files/Nuke16.0v1"
+        CACHE PATH "Nuke library directory")
+else()
+    set(NDK_ROOT "$ENV{HOME}/Nuke/Nuke16.0v7/include"
+        CACHE PATH "Nuke NDK include directory")
+    set(NUKE_LIB_DIR "$ENV{HOME}/Nuke/Nuke16.0v7"
+        CACHE PATH "Nuke library directory")
+endif()
 
 # ---------------------------------------------------------------------------
 # Plugin target
@@ -36,41 +51,58 @@ target_include_directories(NukeFlareSim PRIVATE
 )
 
 target_compile_definitions(NukeFlareSim PRIVATE
-    NOMINMAX            # required by Nuke NDK (fnVC.h enforces this)
-    _USE_MATH_DEFINES   # required by Nuke NDK (fnVC.h enforces this); exposes M_PI etc.
-    WIN32_LEAN_AND_MEAN
+    NOMINMAX
+    _USE_MATH_DEFINES
 )
+if(WIN32)
+    target_compile_definitions(NukeFlareSim PRIVATE WIN32_LEAN_AND_MEAN)
+endif()
 
-# CXX: treat warnings as informational only; keep /W3.
-# /wd4996 suppresses the STL3DAllocator deprecation warnings that originate
-# inside Nuke's own DDImage headers (Attribute.h, Primitive.h, Allocators.h).
-target_compile_options(NukeFlareSim PRIVATE
-    $<$<COMPILE_LANGUAGE:CXX>:/W3 /wd4996>
-)
+# Platform-specific compile options
+if(MSVC)
+    target_compile_options(NukeFlareSim PRIVATE
+        $<$<COMPILE_LANGUAGE:CXX>:/W3 /wd4996>
+    )
+else()
+    target_compile_options(NukeFlareSim PRIVATE
+        $<$<COMPILE_LANGUAGE:CXX>:-Wall -Wno-deprecated-declarations>
+    )
+endif()
 
-# CUDA: allow constexpr functions to be used on device without __device__ tags;
-# required for some C++17 standard-library helpers used in device-side headers.
+# CUDA: allow constexpr functions to be used on device without __device__ tags
 target_compile_options(NukeFlareSim PRIVATE
     $<$<COMPILE_LANGUAGE:CUDA>:--expt-relaxed-constexpr>
 )
 
-target_link_libraries(NukeFlareSim PRIVATE
-    "${NUKE_LIB_DIR}/DDImage.lib"
-    "${NUKE_LIB_DIR}/Ndk.lib"
-)
+# Link against Nuke libraries
+if(WIN32)
+    target_link_libraries(NukeFlareSim PRIVATE
+        "${NUKE_LIB_DIR}/DDImage.lib"
+        "${NUKE_LIB_DIR}/Ndk.lib"
+    )
+else()
+    target_link_libraries(NukeFlareSim PRIVATE
+        "${NUKE_LIB_DIR}/libDDImage.so"
+        "${NUKE_LIB_DIR}/libNdk.so"
+    )
+endif()
 
-# Nuke expects the plugin as a plain .dll with no "lib" prefix.
+# Nuke expects the plugin with no "lib" prefix.
+# Windows: .dll, Linux: .so.
+if(WIN32)
+    set(FLARESIM_PLUGIN_EXT ".dll")
+else()
+    set(FLARESIM_PLUGIN_EXT ".so")
+endif()
 set_target_properties(NukeFlareSim PROPERTIES
-    OUTPUT_NAME "FlareSim"     # DLL name must match the registered node class name
+    OUTPUT_NAME "FlareSim"
     PREFIX ""
-    SUFFIX ".dll"
+    SUFFIX "${FLARESIM_PLUGIN_EXT}"
     CUDA_SEPARABLE_COMPILATION OFF
 )
 
 # ---------------------------------------------------------------------------
-# Install helper — copies the DLL into the directory pointed to by
-# the NUKE_PLUGIN_DIR cache variable if provided.
-# Usage: cmake -DNUKE_PLUGIN_DIR="C:/Users/Steve/.nuke/plugins" ..
+# Install helper
 # ---------------------------------------------------------------------------
 if(DEFINED NUKE_PLUGIN_DIR)
     install(TARGETS NukeFlareSim DESTINATION "${NUKE_PLUGIN_DIR}")


### PR DESCRIPTION
## Summary

- Adds `if(WIN32)`/`if(MSVC)` guards around all Windows-specific CMake settings so the plugin builds on Linux with GCC + CUDA toolkit
- Uses **static CUDA runtime** on Linux to avoid conflicts with Nuke's bundled `libcudart.so.11` (keeps shared on Windows as before)
- Adds GCC compile options (`-Wall`, `-Wno-deprecated-declarations`) as equivalents to MSVC `/W3 /wd4996`
- Links against `.so` instead of `.lib`, outputs `.so` instead of `.dll` on Linux
- Adds Blackwell (`sm_120`) to `CMAKE_CUDA_ARCHITECTURES`
- Adds default Linux Nuke NDK paths (overridable via `cmake -DNDK_ROOT=... -DNUKE_LIB_DIR=...`)

No C++ or CUDA source code changes — the plugin code is already fully portable. All changes are confined to `CMakeLists.txt`.

## Linux build instructions

```bash
git clone https://github.com/LocalStarlight/flaresim_nuke.git
cd flaresim_nuke && mkdir build && cd build
cmake .. -DCMAKE_BUILD_TYPE=Release \
    -DNDK_ROOT="/path/to/Nuke16/include" \
    -DNUKE_LIB_DIR="/path/to/Nuke16"
make -j$(nproc)
cp FlareSim.so ~/.nuke/plugins/FlareSim_v1.0.0_Nuke16/
```

## Why static CUDA runtime on Linux?

Nuke 16 bundles `libcudart.so.11.8`. When the plugin is built with a newer CUDA toolkit (e.g. 13.x) and dynamically links `libcudart.so.13`, Nuke's loader resolves CUDA symbols from its own bundled runtime, causing a version mismatch that results in silent CUDA failures and blank output. Statically linking the CUDA runtime embeds it into the `.so` and eliminates the conflict.

## Test environment

- CachyOS (Arch-based) Linux 6.19.5, GCC 15.2.1, CUDA 13.1
- Nuke 16.0v7, NVIDIA RTX 5090 (compute capability 12.0)
- Verified: plugin loads, lens files load, ghost rendering produces correct output